### PR TITLE
OAP-94 Add Python libs to TeamCity agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,6 @@ RUN sudo apt-get install -y ruby-dev build-essential && sudo gem i fpm -f
 # Cypress
 COPY keyboard /etc/default/    
 
-RUN sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb python3-pip
 RUN pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,4 +97,5 @@ RUN sudo apt-get install -y ruby-dev build-essential && sudo gem i fpm -f
 COPY keyboard /etc/default/    
 
 RUN sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
     


### PR DESCRIPTION
[OAP-94](https://youtrack.xenoss.io/issue/OAP-94) Add Python libs to TeamCity agent

For preparing reports we need Python on the agent:
```
apt-get install python3-pip
pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
```
![image](https://user-images.githubusercontent.com/11904420/211014120-3ddd464f-fe6c-4572-bf3d-bd29d6ea533a.png)
